### PR TITLE
Detect clipboard change using signals instead od busy-waiting.

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -23,7 +23,6 @@
 #include <gtk/gtk.h>
 #include "daemon.h"
 
-static gint timeout_id;
 static gchar *primary_text;
 static gchar *clipboard_text;
 static GtkClipboard *primary;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -23,13 +23,11 @@
 #include <gtk/gtk.h>
 #include "daemon.h"
 
-
 static gint timeout_id;
 static gchar *primary_text;
 static gchar *clipboard_text;
 static GtkClipboard *primary;
 static GtkClipboard *clipboard;
-
 
 /* Called during the daemon loop to protect primary/clipboard contents */
 static void daemon_check()
@@ -82,31 +80,15 @@ static void daemon_check()
 	g_free(clipboard_temp);
 }
 
-/* Called if timeout was destroyed */
-static void reset_daemon(gpointer data)
-{
-	if (timeout_id != 0)
-		g_source_remove(timeout_id);
-	/* Add the daemon loop */
-	timeout_id = g_timeout_add_full(G_PRIORITY_LOW,
-					DAEMON_INTERVAL,
-					(GSourceFunc)daemon_check,
-					NULL,
-					(GDestroyNotify)reset_daemon);
-}
-
 /* Initializes daemon mode */
 void init_daemon_mode()
 {
 	/* Create clipboard and primary and connect signals */
 	primary = gtk_clipboard_get(GDK_SELECTION_PRIMARY);
 	clipboard = gtk_clipboard_get(GDK_SELECTION_CLIPBOARD);
-	/* Add the daemon loop */
-	timeout_id = g_timeout_add_full(G_PRIORITY_LOW,
-					DAEMON_INTERVAL,
-					(GSourceFunc)daemon_check,
-					NULL,
-					(GDestroyNotify)reset_daemon);
+	/* Register for clipboard change events */
+	g_signal_connect(primary, "owner-change", G_CALLBACK(daemon_check), NULL);
+	g_signal_connect(clipboard, "owner-change", G_CALLBACK(daemon_check), NULL);
 
 	/* Start daemon loop */
 	gtk_main();

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -24,8 +24,6 @@
 
 G_BEGIN_DECLS
 
-#define DAEMON_INTERVAL 500
-
 void init_daemon_mode();
 
 G_END_DECLS

--- a/src/main.c
+++ b/src/main.c
@@ -67,7 +67,7 @@ prefs_t prefs = {DEF_USE_COPY,         DEF_USE_PRIMARY,      DEF_SYNCHRONIZE,
                  INIT_SEARCH_KEY,      INIT_OFFLINE_KEY,     DEF_NO_ICON,
                  DEF_OFFLINE_MODE};
 
-/* Called every CHECK_INTERVAL seconds to check for new items */
+/* Called when clipboard content changes */
 static gboolean item_check(gpointer data) {
   /* Immediately return in offline mode */
   if (prefs.offline_mode)

--- a/src/main.c
+++ b/src/main.c
@@ -808,7 +808,8 @@ static void clipit_init() {
 	/* Create clipboard */
 	primary = gtk_clipboard_get(GDK_SELECTION_PRIMARY);
 	clipboard = gtk_clipboard_get(GDK_SELECTION_CLIPBOARD);
-	g_timeout_add(CHECK_INTERVAL, item_check, NULL);
+	g_signal_connect(primary, "owner-change", G_CALLBACK(item_check), NULL);
+	g_signal_connect(clipboard, "owner-change", G_CALLBACK(item_check), NULL);
 
 	/* Read preferences */
 	read_preferences();

--- a/src/main.h
+++ b/src/main.h
@@ -29,8 +29,6 @@ G_BEGIN_DECLS
 
 #define ACTIONS_TAB    2
 #define POPUP_DELAY    30
-#define CHECK_INTERVAL 500
-
 #define UNUSED(x)      (void)(x)
 
 typedef struct {


### PR DESCRIPTION
This improves battery life by avoid busy waiting.
